### PR TITLE
Remove extra scroll bars on smaller displays for better responsiveness

### DIFF
--- a/frontend/src/components/Footer/Footer.module.scss
+++ b/frontend/src/components/Footer/Footer.module.scss
@@ -6,7 +6,7 @@
   position: relative;
   bottom: 0;
   z-index: 1000;  
-  height: 150px;  
+  height: 120px;  
 }
 
 @media (min-width: 1100px){
@@ -23,6 +23,10 @@
     left: 25px;
     right: 25px;
     padding: 0px 0px;
+    background-color: white;
+    position: sticky;
+    bottom: 0;
+    box-shadow: 0 -2px 4px 0 rgba(0, 0, 0, 0.1);
   }
 
 }

--- a/frontend/src/pages/Emotion/Emotion.module.scss
+++ b/frontend/src/pages/Emotion/Emotion.module.scss
@@ -11,8 +11,8 @@
 @media (max-width: 1100px) {
   .container {
     width: 85vw;
-    overflow: scroll;
-    height: 75vh;
+    
+    height: auto;
   }
 
   .container::-webkit-scrollbar {

--- a/frontend/src/pages/Emotion/Emotion.module.scss
+++ b/frontend/src/pages/Emotion/Emotion.module.scss
@@ -121,7 +121,7 @@
 @media (max-width: 1100px) {
   .numberBoxes {
     width: 325px;
-    height: 120px;
-    overflow: scroll;
+    height: auto;
+    
   }
 }

--- a/frontend/src/pages/Thought/Thought.module.scss
+++ b/frontend/src/pages/Thought/Thought.module.scss
@@ -110,8 +110,8 @@
 
 @media (max-width: 1100px) {
   .groupContainer {
-    overflow: scroll;
-    height: 300px;
+    
+    height: auto;
   }
 
   .groupContainer::-webkit-scrollbar {


### PR DESCRIPTION
This has the small changes I've shown. Additionally, I changed the styling for the footer which removes extra scroll bars, and also fixes an issue where content is cutoff slightly on small displays. Let me know if you need pictures of how it changed.
